### PR TITLE
Fix All commands greyed out

### DIFF
--- a/core/ajax/jMQTT.ajax.php
+++ b/core/ajax/jMQTT.ajax.php
@@ -91,7 +91,7 @@ try {
         $old_broker_id = $eqpt->getBrkId();
         $new_broker = jMQTT::getBrokerFromId(init('brk_id'));
         log::add('jMQTT', 'info', 'déplace l\'équipement ' . $eqpt->getName() . ' vers le broker ' . $new_broker->getName());
-        $eqpt->setType(jMQTT::TYP_EQPT);
+        $eqpt->setConfType(jMQTT::TYP_EQPT);
         $eqpt->setBrkId($new_broker->getId());
         $eqpt->cleanEquipment();
         $eqpt->save(true);

--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -239,7 +239,7 @@ class jMQTT extends eqLogic {
      */
     public static function createEquipment($broker, $name, $topic, $type) {
         $eqpt = new jMQTT();
-        $eqpt->setType($type);
+        $eqpt->setConfType($type);
         $eqpt->initEquipment($name, $topic, 1);
         
         if (is_object($broker)) {
@@ -1592,7 +1592,7 @@ class jMQTT extends eqLogic {
      * Set this jMQTT object type
      * @param string $type either jMQTT::TYPE_STD or jMQTT::TYP_BRK
      */
-    public function setType($type) {
+    public function setConfType($type) {
         $this->setConfiguration(self::CONF_KEY_TYPE, $type);
     }
 

--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -1593,6 +1593,7 @@ class jMQTT extends eqLogic {
      * @param string $type either jMQTT::TYPE_STD or jMQTT::TYP_BRK
      */
     public function setConfType($type) {
+	if($type != jMQTT::TYPE_STD && $type != jMQTT::TYP_BRK) return;
         $this->setConfiguration(self::CONF_KEY_TYPE, $type);
     }
 

--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -158,7 +158,7 @@ class jMQTT extends eqLogic {
      */
     public function applyTemplate($_template, $_topic, $_keepCmd = true){
 
-        if ($this->getType() != self::TYP_EQPT) {
+        if ($this->getConfType() != self::TYP_EQPT) {
             return true;
         }
 
@@ -190,7 +190,7 @@ class jMQTT extends eqLogic {
      */
     public function createTemplate($_template){
 
-        if ($this->getType() != self::TYP_EQPT) {
+        if ($this->getConfType() != self::TYP_EQPT) {
             return true;
         }
 
@@ -283,7 +283,7 @@ class jMQTT extends eqLogic {
         $this->setAutoAddCmd('1');
         $this->setQos('1');
         
-        if ($this->getType() == self::TYP_BRK) {
+        if ($this->getConfType() == self::TYP_BRK) {
             config::save('log::level::' . $this->getDaemonLogFile(), '{"100":"0","200":"0","300":"0","400":"0","1000":"0","default":"1"}', 'jMQTT');
         }
     }
@@ -365,7 +365,7 @@ class jMQTT extends eqLogic {
         $eqls = self::byType(jMQTT::class);
         $returns = array();
         foreach ($eqls as $eql) {
-            if ($eql->getType() != self::TYP_BRK) {
+            if ($eql->getConfType() != self::TYP_BRK) {
                 $returns[$eql->getBrkId()][] = $eql;
             }
         }
@@ -383,7 +383,7 @@ class jMQTT extends eqLogic {
         if (!isset($this->id) && $this->logicalId == '') {
             $topic = '';
             // Two brokers cannot have the same name => raise an exception if this is the case
-            if ($this->getType() == self::TYP_BRK) {
+            if ($this->getConfType() == self::TYP_BRK) {
                 foreach(self::getBrokers() as $broker) {
                     if ($broker->getName() == $this->getName()) {
                         throw new Exception(__('Un broker portant le même nom existe déjà : ', __FILE__) . $this->getName());
@@ -397,7 +397,7 @@ class jMQTT extends eqLogic {
         if (isset($this->_post_data['action']) && $this->getBrkId() > 0) {
             
             $restart_daemon = false;
-            if ($this->getType() == self::TYP_BRK) {
+            if ($this->getConfType() == self::TYP_BRK) {
                 
                 // If broker has been disabled, stop it
                 if (! $this->getIsEnable() && $this->getDaemonState() != self::DAEMON_NOK) {
@@ -413,7 +413,7 @@ class jMQTT extends eqLogic {
                 }
             }
             
-            if ($this->getType() == self::TYP_EQPT) {
+            if ($this->getConfType() == self::TYP_EQPT) {
                 if ($this->getBroker()->isDaemonToBeRestarted(true)) {
                     $restart_daemon = true;     
                 }
@@ -426,7 +426,7 @@ class jMQTT extends eqLogic {
             if ($restart_daemon) {
                 $this->log('info', 'relance du démon nécessaire');
                 $this->getBroker()->stopDaemon();
-                if ($this->getType() == self::TYP_BRK) {
+                if ($this->getConfType() == self::TYP_BRK) {
                     $this->setIncludeMode(0);
                 }
                 $this->addPostAction(self::POST_ACTION_RESTART_DAEMON, '', '');
@@ -500,7 +500,7 @@ class jMQTT extends eqLogic {
             $this->_post_data['action'] = null;
         }
         
-        if ($this->getType() == self::TYP_BRK) {
+        if ($this->getConfType() == self::TYP_BRK) {
             $this->createMqttClientStatusCmd();
             if ($this->getBrkId() < 0) {
                 $this->setBrkId($this->getId());
@@ -514,7 +514,7 @@ class jMQTT extends eqLogic {
      */
     public function preRemove() {
         $this->_post_data = null;
-        if ($this->getType() == self::TYP_BRK) {
+        if ($this->getConfType() == self::TYP_BRK) {
             $this->log('info', 'removing broker ' . $this->getName());
             
             // Disable first the broker to avoid during removal of the broker to restart the daemon
@@ -735,7 +735,7 @@ class jMQTT extends eqLogic {
     public function getDaemonInfo() {
         $return = array('message' => '', 'launchable' => 'nok', 'state' => 'nok', 'log' => 'nok');
         
-        if ($this->getType() != self::TYP_BRK)
+        if ($this->getConfType() != self::TYP_BRK)
             return $return;
               
         $return['brkId'] = $this->getId();
@@ -1330,7 +1330,7 @@ class jMQTT extends eqLogic {
         
         $d = date('Y-m-d H:i:s');
         $this->setStatus(array('lastCommunication' => $d, 'timeout' => 0));
-        if ($this->getType() == self::TYP_EQPT) {
+        if ($this->getConfType() == self::TYP_EQPT) {
             $this->getBroker()->setStatus(array('lastCommunication' => $d, 'timeout' => 0));
         }
         
@@ -1496,7 +1496,7 @@ class jMQTT extends eqLogic {
         
         // General case
         $keys = array('Qos');
-        if ($this->getType() == self::TYP_BRK) {
+        if ($this->getConfType() == self::TYP_BRK) {
             $keys = array_merge($keys, array('mqttAddress', 'mqttPort', 'mqttUser', 'mqttPass', 'mqttIncTopic', 'api'));
         }
         if (in_array($_key, $keys)) {
@@ -1506,7 +1506,7 @@ class jMQTT extends eqLogic {
         }
         
         // Specific case: MQTT id change
-        if ($this->getType() == self::TYP_BRK && $_key == self::CONF_KEY_MQTT_ID) {
+        if ($this->getConfType() == self::TYP_BRK && $_key == self::CONF_KEY_MQTT_ID) {
             if ($value != $old_value) {
                 // Note: topic (i.e. logicalId) is modified in preSave
                 $this->addPostAction(self::POST_ACTION_BROKER_CLIENT_ID_CHANGED, 'MQTT id', $value, $old_value);
@@ -1523,7 +1523,7 @@ class jMQTT extends eqLogic {
      * @see eqLogic::setName()
      */
     public function setName($_name) {
-        if ($this->getType() == self::TYP_BRK) {
+        if ($this->getConfType() == self::TYP_BRK) {
             if ($_name != $this->name) {
                 $this->_log = $this->getDaemonLogFile(); // To write in the correct log until log is renamed
                 $this->addPostAction(self::POST_ACTION_BROKER_NAME_CHANGED, 'nom du broker', $_name, $this->name);
@@ -1584,7 +1584,7 @@ class jMQTT extends eqLogic {
      * Get this jMQTT object type
      * @return string either jMQTT::TYPE_EQPT, jMQTT::TYP_BRK, or empty string if not defined
      */
-    public function getType() {
+    public function getConfType() {
         return $this->getConf(self::CONF_KEY_TYPE);
     }
     
@@ -1691,7 +1691,7 @@ class jMQTT extends eqLogic {
      */
     public function getBroker() {
         if (! isset($this->_broker)) {
-            if ($this->getType() == self::TYP_BRK)
+            if ($this->getConfType() == self::TYP_BRK)
                 $this->_broker = $this;
             else
                 $this->_broker = self::getBrokerFromId($this->getBrkId());
@@ -1711,7 +1711,7 @@ class jMQTT extends eqLogic {
         if (!is_object($broker)) {
             throw new Exception(__('Pas d\'équipement avec l\'id fourni', __FILE__) . ' (id=' . $id . ')');
         } 
-        if ($broker->getType() != self::TYP_BRK) {
+        if ($broker->getConfType() != self::TYP_BRK) {
             throw new Exception(__('L\'équipement n\'est pas de type broker', __FILE__) . ' (id=' . $id . ')');
         }
         return $broker;

--- a/desktop/php/jMQTT.php
+++ b/desktop/php/jMQTT.php
@@ -119,7 +119,7 @@ function displayActionCard($action_name, $fa_icon, $attr = '', $class = '') {
  */
 function displayEqLogicCard($eqL, $node_images) {
     $opacity = $eqL->getIsEnable() ? '' : 'disableCard';
-    echo '<div class="eqLogicDisplayCard cursor ' . $opacity . '" data-eqLogic_id="' . $eqL->getId() . '" jmqtt_type="' . $eqL->getType() . '">';
+    echo '<div class="eqLogicDisplayCard cursor ' . $opacity . '" data-eqLogic_id="' . $eqL->getId() . '" jmqtt_type="' . $eqL->getConfType() . '">';
     if ($eqL->getConfiguration('auto_add_cmd', 1) == 1) {
        echo '<i class="fas fa-sign-in-alt" style="font-size:0.9em !important;position:absolute;margin-top:10px"></i>';
     }
@@ -128,7 +128,7 @@ function displayEqLogicCard($eqL, $node_images) {
     } else {
         echo '<i class="fas fa-eye-slash" style="font-size:0.9em !important;position:absolute;margin-top:25px"></i>';
     }
-    if ($eqL->getType() == jMQTT::TYP_BRK) {
+    if ($eqL->getConfType() == jMQTT::TYP_BRK) {
         $file = 'node_broker_' . $eqL->getDaemonState() . '.svg';
     }
     else {

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -101,7 +101,7 @@ function migrateToMultiBrokerVersion() {
             log::add('jMQTT', 'debug', 'export before of ' . $eqL->getName());
             log::add('jMQTT', 'debug', json_encode($eqL->full_export()));
 
-            if ($eqL->getType() == '') {
+            if ($eqL->getConfType() == '') {
                 $eqL->setConfType(jMQTT::TYP_EQPT);
                 $eqL->setBrkId($broker->getId());
             }

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -88,7 +88,7 @@ function migrateToMultiBrokerVersion() {
     config::remove('include_mode', 'jMQTT');
     config::remove('status', 'jMQTT');
     
-    $broker->setType(jMQTT::TYP_BRK);
+    $broker->setConfType(jMQTT::TYP_BRK);
     $broker->setBrkId($broker->getId());
     $broker->save(true);
     
@@ -102,7 +102,7 @@ function migrateToMultiBrokerVersion() {
             log::add('jMQTT', 'debug', json_encode($eqL->full_export()));
 
             if ($eqL->getType() == '') {
-                $eqL->setType(jMQTT::TYP_EQPT);
+                $eqL->setConfType(jMQTT::TYP_EQPT);
                 $eqL->setBrkId($broker->getId());
             }
             $eqL->cleanEquipment();


### PR DESCRIPTION
After manipulation (resize, reorder, etc.) of a jMQTT equipement in a View, "Save" overrides type of equipement from 'eqpt' to 'eqLogic'.
Equipement settings and all commands are then greyed out.