### PR TITLE
2021-04-13

### DIFF
--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -280,7 +280,12 @@ class jMQTT extends eqLogic {
         parent::setName($name);
         parent::setIsEnable($isEnable);
         parent::setLogicalId($topic);  // logical id is also modified by setTopic
-        $this->setAutoAddCmd('1');
+        if ($this->getType() == self::TYP_BRK) {
+            $this->setAutoAddCmd('0');
+        }
+        else {
+            $this->setAutoAddCmd('1');
+        }
         $this->setQos('1');
         
         if ($this->getType() == self::TYP_BRK) {

--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -717,7 +717,9 @@ class jMQTT extends eqLogic {
      */
     public static function post_dependancy_install() {
         log::add('jMQTT', 'info', 'Post-Installation des dépendances');
+        // if Mosquitto is installed
         if (config::byKey('installMosquitto', 'jMQTT', 1)) {
+            //looking for broker pointing to local mosquitto
             $brokerexists = false;
             foreach(self::getBrokers() as $broker) {
                 if ($broker->getMqttAddress() == self::getDefaultConfiguration(self::CONF_KEY_MQTT_ADDRESS)) {
@@ -726,8 +728,18 @@ class jMQTT extends eqLogic {
             }
 
             if (!$brokerexists) {
-                log::add('jMQTT', 'info', 'Création du broker local');
+                $brokername = 'local';
+
+                //looking for broker name conflict
                 // TODO
+                log::add('jMQTT', 'info', 'Création du broker '.$brokername);
+                $broker = new jMQTT();
+                $broker->setType(self::TYP_BRK);
+                $broker->initEquipment($brokername, self::getDefaultConfiguration(self::CONF_KEY_MQTT_ID).'/#', '1');
+                $broker->save();
+                $broker->setBrkId($broker->getId());
+                $broker->save();
+                $broker->createMqttClientStatusCmd();
             }
         }
     }

--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -728,10 +728,32 @@ class jMQTT extends eqLogic {
             }
 
             if (!$brokerexists) {
+
                 $brokername = 'local';
 
                 //looking for broker name conflict
-                // TODO
+                $brokernameconflict = $false;
+                foreach(self::getBrokers() as $broker) {
+                    if ($broker->getName() == $brokername) {
+                        $brokernameconflict = true;
+                        break;
+                    }
+                }
+                if ($brokernameconflict) {
+                    $i = 0;
+                    do {
+                        $i++;
+                        $brokernameconflict = $false;
+                        $brokername = 'local'.$i;
+                        foreach(self::getBrokers() as $broker) {
+                            if ($broker->getName() == $brokername) {
+                                $brokernameconflict = true;
+                                break;
+                            }
+                        }
+                    } while ($brokernameconflict);
+                }
+
                 log::add('jMQTT', 'info', 'Création du broker '.$brokername);
                 $broker = new jMQTT();
                 $broker->setType(self::TYP_BRK);

--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -712,6 +712,26 @@ class jMQTT extends eqLogic {
             config::byKey('installMosquitto', 'jMQTT', 1),'log' => log::getPathToLog(self::$_depLogFile));
     }
 
+    /**
+     * Create first broker eqpt if mosquitto has been installed
+     */
+    public static function post_dependancy_install() {
+        log::add('jMQTT', 'info', 'Post-Installation des dépendances');
+        if (config::byKey('installMosquitto', 'jMQTT', 1)) {
+            $brokerexists = false;
+            foreach(self::getBrokers() as $broker) {
+                if ($broker->getMqttAddress() == self::getDefaultConfiguration(self::CONF_KEY_MQTT_ADDRESS)) {
+                    $brokerexists = true;
+                }
+            }
+
+            if (!$brokerexists) {
+                log::add('jMQTT', 'info', 'Création du broker local');
+                // TODO
+            }
+        }
+    }
+
     ###################################################################################################################
     ##
     ##                   DAEMON RELATED METHODS

--- a/core/class/jMQTTCmd.class.php
+++ b/core/class/jMQTTCmd.class.php
@@ -243,7 +243,7 @@ class jMQTTCmd extends cmd {
         // the desktop interface - fix issue #28)
         foreach(array('request') as $key) {
             $conf = $this->getConfiguration($key);
-            if (is_array($conf) && (($conf = json_encode($conf, JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK)) !== FALSE))
+            if (is_array($conf) && (($conf = json_encode($conf, JSON_UNESCAPED_UNICODE)) !== FALSE))
                 $this->setConfiguration($key, $conf);
         }
 

--- a/desktop/js/jMQTT.js
+++ b/desktop/js/jMQTT.js
@@ -110,7 +110,7 @@ function refreshEqLogicPage() {
 
 $(document).ready(function() {
     // On page load, show the commandtab menu bar if necessary (fix #64)
-    if (document.location.hash == '#commandtab') {
+    if (document.location.hash == '#commandtab' && $('.eqLogicAttr[data-l1key="configuration"][data-l2key="type"]').value() != 'broker') {
         $('#menu-bar').show();
     }
     
@@ -172,7 +172,9 @@ $('.nav-tabs a[href="#eqlogictab"],.nav-tabs a[href="#brokertab"]').on('click', 
 });
 
 $('.nav-tabs a[href="#commandtab"]').on('click', function() {
-    $('#menu-bar').show();
+    if($('.eqLogicAttr[data-l1key="configuration"][data-l2key="type"]').value() != 'broker') {
+        $('#menu-bar').show();
+    }
 });
 
 // Configure the sortable functionality of the commands array

--- a/desktop/modal/health.php
+++ b/desktop/modal/health.php
@@ -59,16 +59,17 @@ echo '</tbody></table>';
 foreach ($eqBrokers as $eqB) {
     echo '<legend><i class="fas fa-table"></i> {{Equipements connectés à}} ' . $eqB->getName() . '</legend>';
     echo '<table class="table table-condensed tablesorter" id="table_healthMQTT">';
-    echo '<thead><tr><th>{{Module}}</th><th>{{ID}}</th><th>{{Activé}}</th><th>{{Dernière communication}}</th><th>{{Date création}}</th></tr></thead><tbody>';
+    echo '<thead><tr><th>{{Module}}</th><th>{{ID}}</th><th>{{Activé}}</th><th>{{Inscrit au Topic}}</th><th>{{Broker}}</th><th>{{Dernière communication}}</th><th>{{Date création}}</th></tr></thead><tbody>';
     if (array_key_exists($eqB->getId(), $eqNonBrokers)) {
         foreach ($eqNonBrokers[$eqB->getId()] as $eqL) {
             echo '<tr><td><a href="' . $eqL->getLinkToConfiguration() . '" style="text-decoration: none;">' . $eqL->getHumanName(true) . '</a></td>';
             echo '<td><span class="label label-info" style="font-size : 1em; cursor : default;">' . $eqL->getId() . '</span></td>';
             echo '<td>' . getIsEnableHtml($eqL) . '</td>';
+            echo '<td><span class="label label-info" style="font-size : 1em; cursor : default;">' . $eqL->getLogicalId() . '</span></td>';
+            echo '<td><span class="label label-info" style="font-size : 1em; cursor : default;">' . $eqB->getHumanName(true) . '</span></td>';
             echo '<td><span class="label label-info" style="font-size : 1em; cursor : default;">' . $eqL->getStatus('lastCommunication') . '</span></td>';
-            echo '<td><span class="label label-info" style="font-size : 1em; cursor : default;">' . $eqL->getConfiguration('createtime') . '</span></td></tr>';            
+            echo '<td><span class="label label-info" style="font-size : 1em; cursor : default;">' . $eqL->getConfiguration('createtime') . '</span></td></tr>';
         }
-    }   
+    }
     echo '</tbody></table>';
 }
-    

--- a/desktop/modal/health.php
+++ b/desktop/modal/health.php
@@ -59,14 +59,13 @@ echo '</tbody></table>';
 foreach ($eqBrokers as $eqB) {
     echo '<legend><i class="fas fa-table"></i> {{Equipements connectés à}} ' . $eqB->getName() . '</legend>';
     echo '<table class="table table-condensed tablesorter" id="table_healthMQTT">';
-    echo '<thead><tr><th>{{Module}}</th><th>{{ID}}</th><th>{{Activé}}</th><th>{{Inscrit au Topic}}</th><th>{{Broker}}</th><th>{{Dernière communication}}</th><th>{{Date création}}</th></tr></thead><tbody>';
+    echo '<thead><tr><th>{{Module}}</th><th>{{ID}}</th><th>{{Activé}}</th><th>{{Inscrit au Topic}}</th><th>{{Dernière communication}}</th><th>{{Date création}}</th></tr></thead><tbody>';
     if (array_key_exists($eqB->getId(), $eqNonBrokers)) {
         foreach ($eqNonBrokers[$eqB->getId()] as $eqL) {
             echo '<tr><td><a href="' . $eqL->getLinkToConfiguration() . '" style="text-decoration: none;">' . $eqL->getHumanName(true) . '</a></td>';
             echo '<td><span class="label label-info" style="font-size : 1em; cursor : default;">' . $eqL->getId() . '</span></td>';
             echo '<td>' . getIsEnableHtml($eqL) . '</td>';
             echo '<td><span class="label label-info" style="font-size : 1em; cursor : default;">' . $eqL->getLogicalId() . '</span></td>';
-            echo '<td><span class="label label-info" style="font-size : 1em; cursor : default;">' . $eqB->getHumanName(true) . '</span></td>';
             echo '<td><span class="label label-info" style="font-size : 1em; cursor : default;">' . $eqL->getStatus('lastCommunication') . '</span></td>';
             echo '<td><span class="label label-info" style="font-size : 1em; cursor : default;">' . $eqL->getConfiguration('createtime') . '</span></td></tr>';
         }

--- a/desktop/modal/health.php
+++ b/desktop/modal/health.php
@@ -57,7 +57,7 @@ foreach ($eqBrokers as $eqB) {
 echo '</tbody></table>';
 
 foreach ($eqBrokers as $eqB) {
-    echo '<legend><i class="fas fa-table"></i> {{Equipements connectés à}} ' . $eqB->getName() . '</legend>';
+    echo '<legend><i class="fas fa-table"></i> {{Equipements connectés à}} <b>' . $eqB->getName() . '</b></legend>';
     echo '<table class="table table-condensed tablesorter" id="table_healthMQTT">';
     echo '<thead><tr><th>{{Module}}</th><th>{{ID}}</th><th>{{Activé}}</th><th>{{Inscrit au Topic}}</th><th>{{Dernière communication}}</th><th>{{Date création}}</th></tr></thead><tbody>';
     if (array_key_exists($eqB->getId(), $eqNonBrokers)) {

--- a/desktop/php/jMQTT.php
+++ b/desktop/php/jMQTT.php
@@ -174,7 +174,7 @@ function displayEqLogicCard($eqL, $node_images) {
     
         <?php
         foreach ($eqBrokers as $eqB) {
-            echo '<legend><i class="fas fa-table"></i> {{Equipements connectés à}} ' . $eqB->getName() . '</legend>';
+            echo '<legend><i class="fas fa-table"></i> {{Equipements connectés à}} <b>' . $eqB->getName() . '</b></legend>';
             echo '<div class="eqLogicThumbnailContainer">';
             displayActionCard('{{Ajouter un équipement}}', 'fa-plus-circle', 'data-action="add_jmqtt" brkId="' . 
                 $eqB->getId() . '"', 'logoSecondary', true);

--- a/desktop/php/jMQTT.php
+++ b/desktop/php/jMQTT.php
@@ -244,9 +244,9 @@ function displayEqLogicCard($eqL, $node_images) {
         <div class="tab-content" style="height: calc(100% - 120px); overflow: auto; overflow-x: hidden;">
             <div role="tabpanel" class="tab-pane active" id="eqlogictab">
                 <?php include_file('desktop', 'jMQTT_eqpt', 'php', 'jMQTT'); ?>
-	        </div>
+            </div>
             <div role="tabpanel" class="tab-pane toDisable" id="brokertab">
-                <?php include_file('desktop', 'jMQTT_broker', 'php', 'jMQTT'); ?>                
+                <?php include_file('desktop', 'jMQTT_broker', 'php', 'jMQTT'); ?>
             </div>
             <div role="tabpanel" class="tab-pane toDisable" id="commandtab">
                 <table id="table_cmd" class="table tree table-bordered table-condensed table-striped">

--- a/desktop/php/jMQTT_broker.php
+++ b/desktop/php/jMQTT_broker.php
@@ -124,8 +124,8 @@
                             <label class="col-lg-4 control-label">{{Accès API : }}</label>
                             <div class="col-lg-4">
                                 <select class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="api" style="margin-top: 5px">
-                                    <option value="enable">{{Activé}}</option>
                                     <option value="disable">{{Désactivé}}</option>
+                                    <option value="enable">{{Activé}}</option>
                                 </select>
                             </div>
                         </div>

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -1,5 +1,8 @@
 # Registre des évolutions
 
+## beta
+  - Correction de la conversion de texte transformé en entier dans les payload (Ex : {"bidule":"007"} -> {"bidule":7})
+
 ## 2021-04-07
   - Mises à jour du README, de la documentation et des informations du plugin
   - Amélioration de la remontée du niveau de batterie : la valeur ne doit pas être un JSON (JSON pas encore éclaté d'un auto-inclusion) ou vide

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -3,6 +3,7 @@
 ## beta
   - Correction de la conversion de texte transformé en entier dans les payload (Ex : {"bidule":"007"} -> {"bidule":7})
   - Les équipements de type broker ne sont plus en mode ajout automatique à la création
+  - on ne peux plus ajouter/supprimer de commandes sur les équipements de type Broker
 
 ## 2021-04-07
   - Mises à jour du README, de la documentation et des informations du plugin

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -1,6 +1,6 @@
 # Registre des évolutions
 
-## beta
+## 2021-04-13
   - Correction de la conversion de texte transformé en entier dans les payload (Ex : {"bidule":"007"} -> {"bidule":7})
   - Les équipements de type broker ne sont plus en mode ajout automatique à la création
   - on ne peux plus ajouter/supprimer de commandes sur les équipements de type Broker

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -5,7 +5,8 @@
   - Les équipements de type broker ne sont plus en mode ajout automatique à la création
   - on ne peux plus ajouter/supprimer de commandes sur les équipements de type Broker
   - Ajout dans la santé du plugin du champ "Inscrit au Topic" sur chaque équipement
-  - l'API JSON RPC over MQTT est maintenant désactivé par défaut
+  - l'API JSON RPC over MQTT est maintenant désactivée par défaut
+  - Création d'un broker par défaut suite à l'installation de mosquitto
 
 ## 2021-04-07
   - Mises à jour du README, de la documentation et des informations du plugin

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -5,6 +5,7 @@
   - Les équipements de type broker ne sont plus en mode ajout automatique à la création
   - on ne peux plus ajouter/supprimer de commandes sur les équipements de type Broker
   - Ajout dans la santé du plugin du champ "Inscrit au Topic" sur chaque équipement
+  - l'API JSON RPC over MQTT est maintenant désactivé par défaut
 
 ## 2021-04-07
   - Mises à jour du README, de la documentation et des informations du plugin

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -4,7 +4,7 @@
   - Correction de la conversion de texte transformé en entier dans les payload (Ex : {"bidule":"007"} -> {"bidule":7})
   - Les équipements de type broker ne sont plus en mode ajout automatique à la création
   - on ne peux plus ajouter/supprimer de commandes sur les équipements de type Broker
-  - Ajout dans la santé du plugin des champs "Inscrit au Topic" et "Broker" sur chaque équipement
+  - Ajout dans la santé du plugin du champ "Inscrit au Topic" sur chaque équipement
 
 ## 2021-04-07
   - Mises à jour du README, de la documentation et des informations du plugin

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -2,6 +2,7 @@
 
 ## beta
   - Correction de la conversion de texte transformé en entier dans les payload (Ex : {"bidule":"007"} -> {"bidule":7})
+  - Les équipements de type broker ne sont plus en mode ajout automatique à la création
 
 ## 2021-04-07
   - Mises à jour du README, de la documentation et des informations du plugin

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -4,6 +4,7 @@
   - Correction de la conversion de texte transformé en entier dans les payload (Ex : {"bidule":"007"} -> {"bidule":7})
   - Les équipements de type broker ne sont plus en mode ajout automatique à la création
   - on ne peux plus ajouter/supprimer de commandes sur les équipements de type Broker
+  - Ajout dans la santé du plugin des champs "Inscrit au Topic" et "Broker" sur chaque équipement
 
 ## 2021-04-07
   - Mises à jour du README, de la documentation et des informations du plugin

--- a/resources/install_apt.sh
+++ b/resources/install_apt.sh
@@ -135,6 +135,9 @@ if [ -n PHP_DEV_LIB ]; then
 	fi
 fi
 
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+php -r 'include "../core/class/jMQTT.class.php"; jMQTT::post_dependancy_install();'
+
 rm ${PROGRESS_FILE}
 
 echo "********************************************************"

--- a/resources/install_apt.sh
+++ b/resources/install_apt.sh
@@ -136,7 +136,7 @@ if [ -n PHP_DEV_LIB ]; then
 fi
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"
-php -r 'include "../core/class/jMQTT.class.php"; jMQTT::post_dependancy_install();'
+sudo -u www-data php -r 'include "../core/class/jMQTT.class.php"; jMQTT::post_dependancy_install();'
 
 rm ${PROGRESS_FILE}
 


### PR DESCRIPTION
  - Correction de la conversion de texte transformé en entier dans les payload (Ex : {"bidule":"007"} -> {"bidule":7})
  - Les équipements de type broker ne sont plus en mode ajout automatique à la création
  - on ne peux plus ajouter/supprimer de commandes sur les équipements de type Broker
  - Ajout dans la santé du plugin du champ "Inscrit au Topic" sur chaque équipement
  - l'API JSON RPC over MQTT est maintenant désactivée par défaut
  - Création d'un broker par défaut suite à l'installation de mosquitto