### PR TITLE
Fix missing remove right icon

### DIFF
--- a/desktop/js/jMQTT.js
+++ b/desktop/js/jMQTT.js
@@ -698,7 +698,7 @@ function addCmdToTable(_cmd) {
         else {
             tr += '</td><td>';
         }
-        if (_cmd.id != undefined && _cmd.configuration.irremovable == undefined) {
+        if (_cmd.configuration.irremovable == undefined) {
             tr += ' <a class="btn btn-default btn-xs cmdAction pull-right" data-action="remove"><i class="fas fa-minus-circle"></i></a>';
         }
         tr += '</td></tr>';


### PR DESCRIPTION
Fix missing "remove line" right icon on a newly created info command:
https://www.awesomescreenshot.com/image/7409786?key=e3a9501c3c27f7d444ee70517800e2ad