### PR TITLE
Added TLS support in Broker config panel

### DIFF
--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -45,7 +45,7 @@ class jMQTT extends jMQTTBase {
     const CONF_KEY_MQTT_PASS = 'mqttPass';
     const CONF_KEY_MQTT_TLS = 'mqttTls';
     const CONF_KEY_MQTT_TLS_CA = 'mqttTlsCaFile';
-    const CONF_KEY_MQTT_TLS_INSECURE = 'mqttTlsInsecure';
+    const CONF_KEY_MQTT_TLS_INSECURE = 'mqttTlsSecure';
     const CONF_KEY_MQTT_PAHO_LOG = 'mqttPahoLog';
 
     const CONF_KEY_MQTT_INC_TOPIC = 'mqttIncTopic';

--- a/core/class/jMQTTBase.class.php
+++ b/core/class/jMQTTBase.class.php
@@ -176,7 +176,7 @@ class jMQTTBase extends eqLogic {
 
    public static function new_mqtt_client($id, $hostname, $port = 0, $clientid = '', $statustopic = '',
                                           $username = '', $password = '', $tls = False,
-                                          $tlscafile = '', $tlsinsecure = True, $paholog='') {
+                                          $tlscafile = '', $tlssecure = False, $paholog='') {
       $params['cmd']='newMqttClient';
       $params['id']=$id;
       $params['callback']='ws://127.0.0.1:'.config::byKey('websocketport', get_called_class(), get_called_class()::DEFAULT_WEBSOCKET_PORT).'/plugins/jMQTT/core/php/jmqttd.php';
@@ -196,7 +196,7 @@ class jMQTTBase extends eqLogic {
       $params['password']=$password;
       $params['tls']=$tls; // Enable TLS communcation with broker (default TLS port is 8883)
       $params['tlscafile']=$tlscafile; // string path to the Certificate Authority certificate files that are to be treated as trusted by this client
-      $params['tlsinsecure']=$tlsinsecure; // Bool: True -> Check connection against provided CA certificate.
+      $params['tlssecure']=!$tlssecure; // Bool: True -> Check connection against provided CA certificate.
       $params['paholog']=$paholog;
       get_called_class()::send_to_mqtt_daemon($params);
    }

--- a/desktop/php/jMQTT_broker.php
+++ b/desktop/php/jMQTT_broker.php
@@ -88,7 +88,7 @@
                             <label class="col-lg-4 control-label">{{Port de Mosquitto : }}</label>
                             <div class="col-lg-4">
                                 <input class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="mqttPort"
-                                    style="margin-top: 5px" placeholder="1883" />
+                                    style="margin-top: 5px" placeholder="Par défaut 1883 sans TLS et 8883 avec TLS" />
                             </div>
                         </div>
                         <div class="form-group">
@@ -112,6 +112,27 @@
                                     autocomplete="off" style="margin-top: 5px" placeholder="jeedom" />
                             </div>
                         </div>
+
+                        <div class="form-group">
+                            <label class="col-lg-4 control-label">{{Activer TLS : }}</label>
+                            <div class="col-lg-4">
+                                <input type="checkbox" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="mqttTls">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-lg-4 control-label">{{Vérifier la CA du Broker : }}</label>
+                            <div class="col-lg-4">
+                                <input type="checkbox" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="mqttTlsSecure">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-lg-4 control-label">{{Chemin vers le fichier CA du Broker (obligatoire s'il faut vérifier la CA) : }}</label>
+                            <div class="col-lg-4">
+                                <input class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="mqttTlsCaFile"
+                                    autocomplete="off" style="margin-top: 5px" placeholder="jeedom" />
+                            </div>
+                        </div>
+
                         <div class="form-group">
                             <label class="col-lg-4 control-label">{{Topic de souscription en mode inclusion automatique
                                 des équipements : }}</label>

--- a/resources/jmqttd/jmqttd.py
+++ b/resources/jmqttd/jmqttd.py
@@ -78,9 +78,9 @@ class MqttClient:
 			else:
 				logging.warning('Unable to read CA file "%s"', message['tlscafile'])
 
-		self.mqtttlsinsecure = True
-		if 'tlsinsecure' in message:
-			self.mqtttlsinsecure = message['tlsinsecure']
+		self.mqtttlssecure = False
+		if 'tlssecure' in message:
+			self.mqtttlssecure = message['tlssecure']
 
 		self.mqttpaholog = ''
 		if 'paholog' in message and message['paholog'] != '':
@@ -93,7 +93,7 @@ class MqttClient:
 		# Create MQTT Client
 		self.mqttclient = mqtt.Client(self.mqttclientid)
 		# Enable special Paho logging functions
-		if self.mqttpaholog != ''
+		if self.mqttpaholog != '':
 			self.mqttclient.enable_logger(jeedom_utils.convert_log_level(self.mqttpaholog))
 		if self.mqttusername != '':
 			if self.mqttpassword != '':
@@ -102,7 +102,7 @@ class MqttClient:
 				self.mqttclient.username_pw_set(self.mqttusername)
 		if self.mqtttls:
 			self.mqttclient.tls_set(self.mqtttlscafile)
-			self.mqttclient.tls_insecure_set(self.mqtttlsinsecure)
+			self.mqttclient.tls_insecure_set(not self.mqtttlssecure)
 #TODO Expose in "message" other parameters of tls_set()?
 #	Default values:
 #		certfile=None, keyfile=None, cert_reqs=ssl.CERT_REQUIRED,


### PR DESCRIPTION
Using "TLS Secure" naming instead of "TLS Insecure" Paho naming
Automatic default MQTT port selection if TLS or not