### PR TITLE
Fix value displaying from other cmd.id

### DIFF
--- a/desktop/js/jMQTT.js
+++ b/desktop/js/jMQTT.js
@@ -727,7 +727,7 @@ function addCmdToTable(_cmd) {
         jeedom.cmd.changeType($('#table_cmd [tree-id="' + _cmd.tree_id + '"]'), init(_cmd.subType));
 
         function refreshValue(val) {
-            $('#table_cmd [tree-id="' + _cmd.tree_id + '"] .form-control[data-key=value]').value(val);
+            $('#table_cmd [tree-id="' + _cmd.tree_id + '"][data-cmd_id="' + _cmd.id + '"] .form-control[data-key=value]').value(val);
         }
 
         // Display the value. Efficient in JSON view only as _cmd.value was set in JSON view only in printEqLogic.


### PR DESCRIPTION
When moving from one eqLogic to another (in jMQTT only) without reloading the page, the function refreshValue set values from other cmd.id (old eqLogic we switch from).
The more eqLogic we navigate, the more value updates we have to the wrong eqLogic.

First eqLogic:
![Capture d’écran 2021-05-11 à 15 36 19](https://user-images.githubusercontent.com/46993341/117825275-7ccf3380-b26f-11eb-89af-65dab366df09.png)
Than we go to another eqLogic and go back to the first eqLogic and wait for value to update:
![Capture d’écran 2021-05-11 à 15 37 17](https://user-images.githubusercontent.com/46993341/117825444-a0927980-b26f-11eb-92fb-bfe3526ebd74.png)
