### PR TITLE
BETA - Issue with general health

### DIFF
--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -689,8 +689,12 @@ class jMQTT extends eqLogic {
     public static function health() {
         $return = array();
         foreach(self::getBrokers() as $broker) {
+            // if(!$broker->getIsEnable() || $broker->getMqttClientState() == jMQTTBase::MQTTCLIENT_POK || $broker->getMqttClientState() == jMQTTBase::MQTTCLIENT_NOK)
+                // continue;
             $mosqHost = $broker->getConf(self::CONF_KEY_MQTT_ADDRESS);
             $mosqPort = $broker->getConf(self::CONF_KEY_MQTT_PORT);
+            if ($mosqPort == '')
+                $mosqPort = (boolval($broker->getConf(self::CONF_KEY_MQTT_TLS))) ? 8883 : 1883;
             
             $socket = socket_create(AF_INET, SOCK_STREAM, 0);
             $state = false;
@@ -699,6 +703,7 @@ class jMQTT extends eqLogic {
                 socket_close($socket);
             }
         
+            //log::add(__CLASS__, 'debug', 'Health check BrkId:'.$broker->getConf(self::CONF_KEY_BRK_ID) .' host='.$mosqHost.' port='.$mosqPort);
             $return[] = array(
                 'test' => __('Accès au broker', __FILE__) . ' ' . $broker->getName(),
                 'result' => $state ? __('OK', __FILE__) : __('NOK', __FILE__),


### PR DESCRIPTION
Brokers are shown NOK if port is not explicitly set in configuration:
![image](https://user-images.githubusercontent.com/8396512/118408928-2b1c1400-b688-11eb-96da-06787a4716c4.png)

But Daemon is OK
![image](https://user-images.githubusercontent.com/8396512/118408941-42f39800-b688-11eb-9d99-0820de91b90b.png)
And Brokers too:
![image](https://user-images.githubusercontent.com/8396512/118409639-bb0f8d00-b68b-11eb-8c97-a79741b29fd5.png)

The first commented part of the PR may help to implement check, only if Broker is active
The second comments adds some debug