### PR TITLE
Fix issue #110

### DIFF
--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -1383,12 +1383,15 @@ class jMQTT extends eqLogic {
      */
     public function publish($eqName, $topic, $payload, $qos, $retain) {
         
-        if (is_bool($payload)) {
+        if (is_bool($payload) || is_array($payload)) {
             // Fix #80
             // One can wonder why not encoding systematically the message?
             // Answer is that it does not work in some cases:
             //   * If payload is empty => "(null)" is sent instead of (null)
             //   * If payload contains ", they are backslashed \"
+            // Fix #110
+            // Since Core commit https://github.com/jeedom/core/commit/430f0049dc74e914c4166b109fb48b4375f11ead
+            // payload can be more than int/bool/string
             $payload = json_encode($payload);
         }
         $payloadLogMsg = ($payload === '') ? '(null)' : $payload;


### PR DESCRIPTION
Since Jeedom Core commit https://github.com/jeedom/core/commit/430f0049dc74e914c4166b109fb48b4375f11ead evaluateExpression() can return other types than int/bool/string.
In jMQTT::publish(), payload may then be an array so we need to json_encode it.
Discussion about Core is here https://community.jeedom.com/t/modifications-de-jeedom-evaluateexpression-bug/70303