### PR TITLE
jMQTT:cron() prototype to static

### DIFF
--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -844,7 +844,7 @@ class jMQTT extends eqLogic {
      * cron callback
      * check MQTT Clients are up and connected to Websocket
      */
-    public function cron() {
+    public static function cron() {
         self::checkAllMqttClients();
     }
     

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -2,6 +2,7 @@
 
 ## Beta
   - Ajout de la fonctionalité **EXPÉRIMENTALE** "Pub. Auto" qui permet la Publication automatique en MQTT lors du changement du champ Valeur d'une commande action (Attention : la charge engendrée sur le système actuellement inconnue, d'où son coté expérimental.)
+  - Fix du prototype de la fonction jMQTT:cron()
 
 ## 2021-11-16 Template Manager
   - Améliorations mineures du log de DEBUG


### PR DESCRIPTION
As per https://community.jeedom.com/t/plugin-jmqtt-php-deprecated-message/72161