### PR TITLE
Avoid WebSocket message >65535 octets

### DIFF
--- a/resources/jmqttd/jmqttd.py
+++ b/resources/jmqttd/jmqttd.py
@@ -159,6 +159,7 @@ class WebSocketClient:
         self.apikey = message['apikey']
         self.wscallback = message['callback']
         self.fnismqttconnected = fnismqttconnected
+        self.is32b = (sys.maxsize <= 2**32)
 
         # Create WebSocket Client
         self.wsclient = websocket.WebSocketApp(
@@ -197,6 +198,12 @@ class WebSocketClient:
                 continue # Check if should_stop changed
             try:
                 msg = self.q.get(block=False)
+                if self.is32b and len(msg) > 65535:
+                    if logging.getLogger().isEnabledFor(logging.DEBUG):
+                        logging.error('BrkId: % 4s : Ignoring >=64Ko message (See GitHub Issue #121) size=%io msg=%s', self.id, len(msg), m$
+                    else:
+                        logging.error('BrkId: % 4s : Ignoring >=64Ko message (See GitHub Issue #121) size=%io', self.id, len(msg))
+                    continue
                 self.wsclient.send(msg)
                 logging.info('BrkId: % 4s : Sending message to Jeedom : %s', self.id, msg)
             except queue.Empty:

--- a/resources/jmqttd/jmqttd.py
+++ b/resources/jmqttd/jmqttd.py
@@ -200,7 +200,7 @@ class WebSocketClient:
                 msg = self.q.get(block=False)
                 if self.is32b and len(msg) > 65535:
                     if logging.getLogger().isEnabledFor(logging.DEBUG):
-                        logging.error('BrkId: % 4s : Ignoring >=64Ko message (See GitHub Issue #121) size=%io msg=%s', self.id, len(msg), m$
+                        logging.error('BrkId: % 4s : Ignoring >=64Ko message (See GitHub Issue #121) size=%io msg=%s', self.id, len(msg), msg)
                     else:
                         logging.error('BrkId: % 4s : Ignoring >=64Ko message (See GitHub Issue #121) size=%io', self.id, len(msg))
                     continue

--- a/resources/jmqttd/jmqttd.py
+++ b/resources/jmqttd/jmqttd.py
@@ -198,12 +198,15 @@ class WebSocketClient:
                 continue # Check if should_stop changed
             try:
                 msg = self.q.get(block=False)
+                #################################################
+                # TODO Remove when issue https://github.com/ratchetphp/RFC6455/pull/64 is fixed.
                 if self.is32b and len(msg) > 65535:
                     if logging.getLogger().isEnabledFor(logging.DEBUG):
                         logging.error('BrkId: % 4s : Ignoring >=64Ko message (See GitHub Issue #121) size=%io msg=%s', self.id, len(msg), msg)
                     else:
                         logging.error('BrkId: % 4s : Ignoring >=64Ko message (See GitHub Issue #121) size=%io', self.id, len(msg))
                     continue
+                #################################################
                 self.wsclient.send(msg)
                 logging.info('BrkId: % 4s : Sending message to Jeedom : %s', self.id, msg)
             except queue.Empty:


### PR DESCRIPTION
Ignore ​>=64Ko message from Python daemon to PHP daemon using WebSocket lib
On systems running 32bits python/php
Regarding issue https://github.com/Domochip/jMQTT/issues/121