### PR TITLE
Remove batteryStatus from eqLogic if needed

### DIFF
--- a/core/class/jMQTTCmd.class.php
+++ b/core/class/jMQTTCmd.class.php
@@ -118,7 +118,7 @@ class jMQTTCmd extends cmd {
         $this->event($value);
         $this->getEqLogic()->log('info', '-> ' . $this->getLogName() . ' ' . $value);
 
-        if ((preg_match('/(battery|batterie)$/i', $this->getName()) || $this->getGeneric_type() == 'BATTERY') && !in_array($value[0], ['{','[',''])) {
+        if ($this->isBattery() && !in_array($value[0], ['{','[',''])) {
             if ($this->getSubType() == 'binary') {
                 $this->getEqLogic()->batteryStatus($value ? 100 : 10);
             } else {
@@ -284,6 +284,7 @@ class jMQTTCmd extends cmd {
             $this->_preSaveInformations = array(
                 'retain' => $cmd->getConfiguration('retain', 0),
                 'brokerStatusTopic' => $cmd->getTopic(),
+                'battery' => $cmd->isBattery(),
                 'autoPub' => $cmd->getConfiguration('autoPub', 0),
                 'request' => $cmd->getConfiguration('request', '')
             );
@@ -353,6 +354,12 @@ class jMQTTCmd extends cmd {
                     // Just try to remove the previous status topic
                     $eqLogic->publish($eqLogic->getName(), $this->_preSaveInformations['brokerStatusTopic'], '', 1, 1);
                 }
+            }
+
+            // Remove batteryStatus from eqLogic is cmd is no longer a battery
+            if (!$this->isBattery() && $this->_preSaveInformations['battery']) {
+                $eqLogic->setStatus('battery', null);
+                $eqLogic->setStatus('batteryDatetime', null);
             }
 
             // Only Update listener if "autoPub" or "request" has changed
@@ -427,11 +434,17 @@ class jMQTTCmd extends cmd {
      * preRemove method to log that a command is removed
      */
     public function preRemove() {
-        $this->getEqLogic()->log('info', 'Removing command ' . $this->getLogName());
+        $eqLogic = $this->getEqLogic();
+        $eqLogic->log('info', 'Removing command ' . $this->getLogName());
         $listener = listener::searchClassFunctionOption(__CLASS__, 'listenerAction', '"cmd":"'.$this->getId().'"');
         foreach ($listener as $l) {
             log::add('jMQTT', 'debug', 'Listener Removed from #'.$l->getOption('cmd').'#');
             $l->remove();
+        }
+        // Remove batteryStatus from eqLogic on delete
+        if ($this->isBattery() {
+            $eqLogic->setStatus('battery', null);
+            $eqLogic->setStatus('batteryDatetime', null);
         }
     }
 
@@ -520,7 +533,15 @@ class jMQTTCmd extends cmd {
             return self::get_array_value($value, $indexes);
         }
     }
-    
+
+    /**
+     * Return whether or not this command may contain a battery value
+     * @return boolean
+     */
+    public function isBattery() {
+        return $this->getType() == 'info' && ($this->getGeneric_type() == 'BATTERY' || preg_match('/(battery|batterie)$/i', $this->getName()));
+    }
+
     /**
      * Return whether or not this command is derived from a Json payload
      * @return boolean

--- a/core/class/jMQTTCmd.class.php
+++ b/core/class/jMQTTCmd.class.php
@@ -442,7 +442,7 @@ class jMQTTCmd extends cmd {
             $l->remove();
         }
         // Remove batteryStatus from eqLogic on delete
-        if ($this->isBattery() {
+        if ($this->isBattery()) {
             $eqLogic->setStatus('battery', null);
             $eqLogic->setStatus('batteryDatetime', null);
         }


### PR DESCRIPTION
Remove batteryStatus from eqLogic on delete
Add cmd::isBattery() function

Regarding Community thread:
https://community.jeedom.com/t/jmqtt-ne-pas-afficher-les-modules-sur-secteur-dans-les-equipements/73659

**This PR still needs some testing before merge !**