### PR TITLE
Fix errors in HTMLtoXY function

### DIFF
--- a/core/class/jMQTTCmd.class.php
+++ b/core/class/jMQTTCmd.class.php
@@ -634,13 +634,13 @@ class jMQTTCmd extends cmd {
 	 *
 	 * @return array x, y, bri key/value
 	 */
-	public static function HTMLtoXY($color) {
+	public static function HTMLtoXY($_color) {
 
-		$color = str_replace('0x','', $color);
-		$color = str_replace('#','', $color);
-		$red = hexdec(substr($color, 0, 2));
-		$green = hexdec(substr($color, 2, 2));
-		$blue = hexdec(substr($color, 4, 2));
+		$_color = str_replace('0x','', $_color);
+		$_color = str_replace('#','', $_color);
+		$red = hexdec(substr($_color, 0, 2));
+		$green = hexdec(substr($_color, 2, 2));
+		$blue = hexdec(substr($_color, 4, 2));
 
 		// Normalize the values to 1
 		$normalizedToOne['red'] = $red / 255;
@@ -648,6 +648,7 @@ class jMQTTCmd extends cmd {
 		$normalizedToOne['blue'] = $blue / 255;
 
 		// Make colors more vivid
+		$color = array();
 		foreach ($normalizedToOne as $key => $normalized) {
 			if ($normalized > 0.04045) {
 				$color[$key] = pow(($normalized + 0.055) / (1.0 + 0.055), 2.4);


### PR DESCRIPTION
HTMLtoXY function uses first $color as a string and later an array.

As per Issue #157