### PR TITLE
Create eq with template and other modifications

### DIFF
--- a/core/ajax/jMQTT.ajax.php
+++ b/core/ajax/jMQTT.ajax.php
@@ -90,7 +90,8 @@ try {
 		if (!is_object($eqpt) || $eqpt->getEqType_name() != jMQTT::class) {
 			throw new Exception(__('Pas d\'équipement jMQTT avec l\'id fourni', __FILE__) . ' (id=' . init('id') . ')');
 		}
-		$eqpt->applyTemplate(init('name'), init('topic'), init('keepCmd'));
+		$template = jMQTT::templateByName(init('name'));
+		$eqpt->applyATemplate($template, init('topic'), init('keepCmd'));
 		ajax::success();
 	}
 

--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -406,7 +406,7 @@ class jMQTT extends eqLogic {
 	}
 
 	/**
-	 * Create a new equipment given its name, subscription topic, type and broker the equipment is related to.
+	 * Create a new equipment given its name, subscription topic and broker the equipment is related to.
 	 * IMPORTANT: broker can be null, and then this is the responsability of the caller to attach the new equipment to a broker.
 	 * Equipment is enabled, and saved.
 	 * @param jMQTT $broker broker the equipment is related to

--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -156,27 +156,31 @@ class jMQTT extends eqLogic {
 	 */
 	public static function templateByName($_template){
 		// log::add('jMQTT', 'debug', 'templateByName("' . $_template . '")');
-		// Get personal templates
-		foreach (ls(dirname(__FILE__) . '/../../data/template', '*.json', false, array('files', 'quiet')) as $file) {
-			try {
-				$content = file_get_contents(dirname(__FILE__) . '/../../data/template/' . $file);
-				if (is_json($content)) {
-					foreach (json_decode($content, true) as $k => $v)
-						if ('[Perso] '.$k == $_template)
-							return $v;
-				}
-			} catch (Throwable $e) {}
-		}
-		// Get official templates
-		foreach (ls(dirname(__FILE__) . '/../config/template', '*.json', false, array('files', 'quiet')) as $file) {
-			try {
-				$content = file_get_contents(dirname(__FILE__) . '/../config/template/' . $file);
-				if (is_json($content)) {
-					foreach (json_decode($content, true) as $k => $v)
-						if ($k == $_template)
-							return $v;
-				}
-			} catch (Throwable $e) {}
+		if (strpos($_template , '[Perso] ') === 0) {
+			// Get personal templates
+			$_template = substr($_template, strlen('[Perso] '));
+			foreach (ls(dirname(__FILE__) . '/../../data/template', '*.json', false, array('files', 'quiet')) as $file) {
+				try {
+					$content = file_get_contents(dirname(__FILE__) . '/../../data/template/' . $file);
+					if (is_json($content)) {
+						foreach (json_decode($content, true) as $k => $v)
+							if ($k == $_template)
+								return $v;
+					}
+				} catch (Throwable $e) {}
+			}
+		} else {
+			// Get official templates
+			foreach (ls(dirname(__FILE__) . '/../config/template', '*.json', false, array('files', 'quiet')) as $file) {
+				try {
+					$content = file_get_contents(dirname(__FILE__) . '/../config/template/' . $file);
+					if (is_json($content)) {
+						foreach (json_decode($content, true) as $k => $v)
+							if ($k == $_template)
+								return $v;
+					}
+				} catch (Throwable $e) {}
+			}
 		}
 		return null;
 	}

--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -59,6 +59,7 @@ class jMQTT extends eqLogic {
 	const CONF_KEY_QOS = 'Qos';
 	const CONF_KEY_AUTO_ADD_CMD = 'auto_add_cmd';
 	const CONF_KEY_AUTO_ADD_TOPIC = 'auto_add_topic';
+	const CONF_KEY_JSON_PATH = 'jsonPath';
 	const CONF_KEY_API = 'api';
 	const CONF_KEY_LOGLEVEL = 'loglevel';
 
@@ -236,8 +237,8 @@ class jMQTT extends eqLogic {
 						$i = strpos($topic, '{');
 						if ($i === false) {
 							// Just set empty jsonPath if it doesn't exists
-							if (!array_key_exists('jsonPath', $cmd['configuration']))
-								$cmd['configuration']['jsonPath'] = '';
+							if (!array_key_exists(jMQTT::CONF_KEY_JSON_PATH, $cmd['configuration']))
+								$cmd['configuration'][jMQTT::CONF_KEY_JSON_PATH] = '';
 						}
 						else {
 							// Set cleaned Topic
@@ -257,7 +258,7 @@ class jMQTT extends eqLogic {
 								else
 									$jsonPath .= '[' . $index . ']';
 							}
-							$cmd['configuration']['jsonPath'] = $jsonPath;
+							$cmd['configuration'][jMQTT::CONF_KEY_JSON_PATH] = $jsonPath;
 						}
 					}
 				}
@@ -1849,7 +1850,7 @@ class jMQTT extends eqLogic {
 		if (! is_object($this->getMqttClientStatusCmd())) {
 			$cmd = jMQTTCmd::newCmd($this, self::CLIENT_STATUS, $this->getMqttClientStatusTopic());
 			$cmd->setLogicalId(self::CLIENT_STATUS);
-			$cmd->setConfiguration('jsonPath', '');
+			$cmd->setConfiguration(jMQTT::CONF_KEY_JSON_PATH, '');
 			$cmd->setIrremovable();
 			$cmd->save();
 		}

--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -506,7 +506,7 @@ class jMQTT extends eqLogic {
 	public static function getBrokers() {
 		$type = json_encode(array('type' => self::TYP_BRK));
 		/** @var jMQTT[] $brokers */
-		$brokers = self::byTypeAndSearhConfiguration(jMQTT::class, substr($type, 1, -1));
+		$brokers = self::byTypeAndSearchConfiguration(jMQTT::class, substr($type, 1, -1));
 		$returns = array();
 		foreach ($brokers as $broker) {
 			$returns[$broker->getId()] = $broker;
@@ -562,7 +562,7 @@ class jMQTT extends eqLogic {
 
 		//Find eqLogic using the same topic
 		$topicConfiguration = substr(json_encode(array(self::CONF_KEY_AUTO_ADD_TOPIC => $topic)), 1, -1);
-		$eqLogics = jMQTT::byTypeAndSearhConfiguration(__CLASS__, $topicConfiguration);
+		$eqLogics = jMQTT::byTypeAndSearchConfiguration(__CLASS__, $topicConfiguration);
 		$count = 0;
 		foreach ($eqLogics as $eqLogic) {
 			// If it's attached to the same broker and enabled and it's not "me"
@@ -2109,7 +2109,7 @@ class jMQTT extends eqLogic {
 	public static function byBrkId($id) {
 		$brkId = json_encode(array('brkId' => $id));
 		/** @var jMQTT[] $eqpts */
-		$returns = self::byTypeAndSearhConfiguration(jMQTT::class, substr($brkId, 1, -1));
+		$returns = self::byTypeAndSearchConfiguration(jMQTT::class, substr($brkId, 1, -1));
 		return $returns;
 	}
 

--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -324,16 +324,17 @@ class jMQTT extends eqLogic {
 
 	/**
 	 * apply a template (from json) to the current equipement.
-	 * @param string $_template name of the template to apply
+	 * @param array $_template content of the template to apply
+	 * @param string $topic subscription topic
+	 * @param bool   $_keepCmd keep existing commands
 	 */
-	public function applyTemplate($_template, $_topic, $_keepCmd = true){
+	public function applyATemplate($_template, $_topic, $_keepCmd = true){
 
 		if ($this->getType() != self::TYP_EQPT) {
 			return true;
 		}
 
-		$template = self::templateByName($_template);
-		if (is_null($template)) {
+		if (is_null($_template)) {
 			return true;
 		}
 
@@ -341,10 +342,10 @@ class jMQTT extends eqLogic {
 		$this->setCache(self::CACHE_IGNORE_TOPIC_MISMATCH, 1);
 
 		// import template
-		$this->import($template, $_keepCmd);
+		$this->import($_template, $_keepCmd);
 
 		// complete eqpt topic
-		$this->setTopic(sprintf($template['configuration'][self::CONF_KEY_AUTO_ADD_TOPIC], $_topic));
+		$this->setTopic(sprintf($_template['configuration'][self::CONF_KEY_AUTO_ADD_TOPIC], $_topic));
 		$this->save();
 
 		// complete cmd topics

--- a/core/class/jMQTTCmd.class.php
+++ b/core/class/jMQTTCmd.class.php
@@ -490,11 +490,11 @@ class jMQTTCmd extends cmd {
 	}
 
 	public function setJsonPath($jsonPath) {
-		$this->setConfiguration('jsonPath', $jsonPath);
+		$this->setConfiguration(jMQTT::CONF_KEY_JSON_PATH, $jsonPath);
 	}
 
 	public function getJsonPath() {
-		return $this->getConfiguration('jsonPath', '');
+		return $this->getConfiguration(jMQTT::CONF_KEY_JSON_PATH, '');
 	}
 
 	public function splitTopicAndJsonPath() {

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -1,5 +1,9 @@
 # Registre des évolutions
 
+## Beta
+ - Ajout d'une fonction permettant à un plugin tiers d'ajouter/modifier facilement un équipement dans jMQTT avec un template
+ - Modifications et réécritures mineures des certaines fonctions
+
 ## 2022-02-28
  - Correction d'un bug en cas de tentative de suppression d'une commande orpheline (sans EqLogic)
  - Correction du nettoyage des info broker des equipements (les champs ayant '' pour valeur étaient supprimés avant envoi)


### PR DESCRIPTION
Add jMQTT::CONF_KEY_JSON_PATH const for 'jsonPath'
Update jMQTT::applyTemplate() prototype as jMQTT::applyATemplate() : Now takes a template content, not the name of the template
Fix typo in eqLogic::byTypeAndSearhConfiguration as per jeedom/core@a0044e5
Modify jMQTT::createEquipment description
Add jMQTT::createEqWithTemplate static function to create a new equipment given its name, subscription topic and broker the equipment is related to ; as per https://community.jeedom.com/t/jmqtt-et-auto-add-topic/82364/8
Modify jMQTT::templateByName static function: only enter the "personal" loop if $_template starts with '[Perso] ', enter "official" loop otherwise
Update Changelog