### PR TITLE
Using Jeedom address configuration

### DIFF
--- a/core/class/jMQTT.class.php
+++ b/core/class/jMQTT.class.php
@@ -1147,10 +1147,11 @@ class jMQTT extends eqLogic {
 	 */
 	public static function get_callback_url() {
 		$prot = config::byKey('internalProtocol', 'core', 'http://');		// To fix let's encrypt issue like: https://community.jeedom.com/t/87060/26
+		$host = config::byKey('internalAddr', 'core', 'localhost');		// Using Jeedom address configuration
 		$port = config::byKey('internalPort', 'core', 80);					// To fix port issue like: https://community.jeedom.com/t/87060/30
 		$comp = trim(config::byKey('internalComplement', 'core', ''), '/');	// To fix path issue like: https://community.jeedom.com/t/87872/15
 		if ($comp !== '') $comp .= '/';
-		return $prot.'localhost:'.$port.'/'.$comp.'plugins/jMQTT/core/php/callback.php';
+		return $prot.$host.':'.$port.'/'.$comp.'plugins/jMQTT/core/php/callback.php';
 	}
 
 	/**


### PR DESCRIPTION
For people using domain name for accessing on jeedom without localhost url, using this parameter is better.
It populated inside jeedom configuration, like protocol and port configuration.